### PR TITLE
Add kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,4 @@
+bom: rigol-psu-usb-type-c-adapter.kicad_pcb
+eda:
+  type: kicad
+  pcb: rigol-psu-usb-type-c-adapter.kicad_pcb


### PR DESCRIPTION
Hey, I thought this could be a nice little practical project to have a [Kitspace.org](https://kitspace.org) page for. The way it works it needs a manifest file (kitspace.yaml) to make sure it picks up the right files. (You could also add more fields in the manifest, [see here](https://github.com/kitspace/kitspace#kitspaceyaml-format).) 

[Here is a preview of your page](http://try-dp832-usb-c.preview.kitspace.org/boards/github.com/kitspace-forks/rigol-DP832-USB-C-adapter/)

Some things to consider:

- We are currently not using your Gerbers (because they are in a zip, and we can't unzip yet)  so we couldn't use the `gerbers:` field in the yaml)
- The BOM is generated from the .kicad_pcb, which doesn't have the most info so the "Buy Parts" 1-click buying links are not showing up. You could add a .csv/.ods/.xlsx BOM and switch that in in the `bom:` field (I also have [a project](https://github.com/kitspace/bom-builder) to help with that -- [more info](https://kitspace.org/bom-builder), I can give you hosted access if you want, just email me: kaspar@kitspace.org)
- As you update this repo the Kitspace page will update too, it currently re-builds every 3 hours

If you are happy to put the page up, just merge this in and I'll add it. 